### PR TITLE
Bump Node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Prettier CLI arguments
     required: true
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actionsx/prettier"