### PR TITLE
deps(ci): update actions to v4 and node to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 20
 
 jobs:
   test:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: prettier --version
         uses: ./
         with:
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Prettier CLI arguments
     required: true
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Updates `actions/checkout` to v4, `actions/setup-node` to v4 and Node.js to 20 (16 is no longer maintained).

Since this PR is pretty stale, I updated [my fork](https://github.com/Nerixyz/actionsx-prettier) to a new version of prettier (3.3.3) and all actions to the latest versions. If you want to use that fork:

```yml
- uses: Nerixyz/actionsx-prettier@v3-adj
  with:
    # prettier CLI arguments.
    args: --check .
```